### PR TITLE
Se review three

### DIFF
--- a/Controllers/MoviesApi.cs
+++ b/Controllers/MoviesApi.cs
@@ -29,19 +29,31 @@ namespace MoviesBE.Controllers
             app.MapGet("/movies/{movieId}", (MoviesBEDbContext db, int movieId) =>
             {
                 return db.Movies
+                    .Where(m => m.Id == movieId)
                     .Include(m => m.Genres)
                     .Include(m => m.Reviews)
-                     .Select(m => new
-                     {
-                         m.Id,
-                         m.Title,
-                         m.Image,
-                         m.Description,
-                         DateReleased = m.DateReleased.ToString("MM/dd/yyyy"),
-                         m.MovieRating,
-                     })
-                    .FirstOrDefault(m => m.Id == movieId);
+                    .Select(m => new
+                    {
+                        m.Id,
+                        m.Title,
+                        m.Image,
+                        m.Description,
+                        DateReleased = m.DateReleased.ToString("MM/dd/yyyy"),
+                        m.MovieRating,
+                        Genres = m.Genres.Select(g => new { g.Id, g.Name }), // Include genres
+                        Reviews = m.Reviews.Select(r => new
+                        {
+                            r.Id,
+                            r.Rating,
+                            r.UserId,
+                            r.MovieId,
+                            r.CommentReview,
+                            DateCreated = r.DateCreated.ToString("MM/dd/yyyy"),
+                        }) // Include reviews
+                    })
+                    .FirstOrDefault();
             });
+
 
             //get top reviewed 20 movies
             app.MapGet("/movies/toprated", (MoviesBEDbContext db) =>

--- a/Controllers/MoviesApi.cs
+++ b/Controllers/MoviesApi.cs
@@ -13,6 +13,15 @@ namespace MoviesBE.Controllers
                 return db.Movies
                     .Include(m => m.Genres)
                     .Include(m => m.Reviews)
+                    .Select(m => new
+                    {
+                        m.Id,
+                        m.Title,
+                        m.Image,
+                        m.Description,
+                        DateReleased = m.DateReleased.ToString("MM/dd/yyyy"),
+                        m.MovieRating,
+                    })
                     .ToList();
             });
 
@@ -22,23 +31,41 @@ namespace MoviesBE.Controllers
                 return db.Movies
                     .Include(m => m.Genres)
                     .Include(m => m.Reviews)
+                     .Select(m => new
+                     {
+                         m.Id,
+                         m.Title,
+                         m.Image,
+                         m.Description,
+                         DateReleased = m.DateReleased.ToString("MM/dd/yyyy"),
+                         m.MovieRating,
+                     })
                     .FirstOrDefault(m => m.Id == movieId);
             });
 
             //get top reviewed 20 movies
-                app.MapGet("/movies/toprated", (MoviesBEDbContext db) =>
-                {
-                    var movies = db.Movies
-                        .Include(m => m.Reviews)
-                        .ToList();
+            app.MapGet("/movies/toprated", (MoviesBEDbContext db) =>
+            {
+                var movies = db.Movies
+                    .Include(m => m.Reviews)
+                    .ToList();
 
-                    var topRatedMovies = movies
-                        .OrderByDescending(m => m.MovieRating)
-                        .Take(20)
-                        .ToList();
+                var topRatedMovies = movies
+                    .OrderByDescending(m => m.MovieRating)
+                    .Take(20)
+                      .Select(m => new
+                      {
+                          m.Id,
+                          m.Title,
+                          m.Image,
+                          m.Description,
+                          DateReleased = m.DateReleased.ToString("MM/dd/yyyy"),
+                          m.MovieRating,
+                      })
+                    .ToList();
 
-                    return topRatedMovies; 
-                });
+                return topRatedMovies;
+            });
 
             //***get recent 20 movies
             app.MapGet("/movies/recent", (MoviesBEDbContext db) =>
@@ -46,8 +73,18 @@ namespace MoviesBE.Controllers
                 return db.Movies
                     .OrderByDescending(m => m.DateReleased)
                     .Take(20)
+                      .Select(m => new
+                      {
+                          m.Id,
+                          m.Title,
+                          m.Image,
+                          m.Description,
+                          DateReleased = m.DateReleased.ToString("MM/dd/yyyy"),
+                          m.MovieRating,
+                      })
                     .ToList();
             });
+
             //Search movies by Title
             app.MapGet("/movies/search/{query}", (MoviesBEDbContext db, string query) =>
             {
@@ -67,7 +104,6 @@ namespace MoviesBE.Controllers
                     return Results.Ok(filteredPosts);
                 }
             });
-
         }
     }
 }

--- a/Controllers/MoviesApi.cs
+++ b/Controllers/MoviesApi.cs
@@ -48,6 +48,25 @@ namespace MoviesBE.Controllers
                     .Take(20)
                     .ToList();
             });
+            //Search movies by Title
+            app.MapGet("/movies/search/{query}", (MoviesBEDbContext db, string query) =>
+            {
+                if (string.IsNullOrWhiteSpace(query))
+                {
+                    return Results.BadRequest("Search query cannot be empty");
+                }
+
+                var filteredPosts = db.Movies.Where(m => m.Title.ToLower().Contains(query.ToLower())).ToList();
+
+                if (filteredPosts.Count == 0)
+                {
+                    return Results.NotFound("No posts found for the given search query.");
+                }
+                else
+                {
+                    return Results.Ok(filteredPosts);
+                }
+            });
 
         }
     }

--- a/Controllers/UsersApi.cs
+++ b/Controllers/UsersApi.cs
@@ -30,7 +30,7 @@ namespace MoviesBE.Controllers
                     Image = userDto.Image,
                     Email = userDto.Email,
                     Uid = userDto.Uid,
-                    IsAdmin = true,
+                    IsAdmin = false,
                 };
                 db.Users.Add(newUser);
                 db.SaveChanges();

--- a/Dto/MovieToUpdateDto.cs
+++ b/Dto/MovieToUpdateDto.cs
@@ -1,0 +1,14 @@
+﻿using MoviesBE.Models;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoviesBE.Dto
+{
+    public class MovieToUpdateDto
+    {
+        public string Title { get; set; }
+        public string Image { get; set; }
+        public string Description { get; set; }
+        public DateTime DateReleased { get; set; }
+        public List<int> GenreIds { get; set; }
+    }
+}

--- a/Dto/UserMovieDto.cs
+++ b/Dto/UserMovieDto.cs
@@ -1,0 +1,11 @@
+﻿using MoviesBE.Models;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoviesBE.Dto
+{
+    public class UserMovieDto
+    {
+        public int UserId { get; set; }
+        public int MovieId { get; set; }
+    }
+}


### PR DESCRIPTION
## Description
Added create, update, delete movie api calls. 
Added the genre id and name to some of the shaped data for the movie api calls. 
Added a search api call via movie title.

## Related Issue
#2 #1 #9 

## Motivation and Context
If the user is admin, then they can create, edit, and delete a movie.
For the search bar api call, the user can search for a movie via movie title.

## How Can This Be Tested?
The swagger response for create and update a movie is : 
```
{
  "title": "Frozen 2",
  "image": "https://lumiere-a.akamaihd.net/v1/images/p_frozen2_19644_4c4b423d.jpeg",
  "description": "Why was Elsa born with magical powers? What truths about the past await Elsa as she ventures into the unknown to the enchanted forests and dark seas beyond Arendelle? The answers are calling her but also threatening her kingdom. Together with Anna, Kristoff, Olaf and Sven, she'll face a dangerous but remarkable journey. In \"Frozen,\" Elsa feared her powers were too much for the world. In \"Frozen 2,\" she must hope they are enough.",
  "dateReleased": "2019-11-17T15:49:53.944Z",
  "genreIds": [3, 8]
}
```

The response for delete is a 200 Success in Swagger
The response for the search bar api call is a 200 Success in Swagger

## Screenshots (if appropriate):
![image](https://github.com/GitEbachS/MoviesBE/assets/119310701/c012d1e9-ae94-4383-bfc5-dcc5e3912864)
![image](https://github.com/GitEbachS/MoviesBE/assets/119310701/f6cb8e03-414b-4ae7-849e-16a3a3b19781)
![image](https://github.com/GitEbachS/MoviesBE/assets/119310701/ce5ee825-153b-47d1-bf3d-89abf9da4b85)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)