### PR TITLE
Se rec

### DIFF
--- a/Controllers/MoviesApi.cs
+++ b/Controllers/MoviesApi.cs
@@ -222,17 +222,24 @@ namespace MoviesBE.Controllers
 
             //movie recommendations
             //add movie recommendation
-            app.MapPost("/recommendations/new", (MoviesBEDbContext db, Recommendation newRec) =>
+            app.MapPost("/recommendations/new", (MoviesBEDbContext db, RecommendationsDto newRecDto) =>
             {
                 // Check if the movie and user exist
-                if (!db.Movies.Any(m => m.Id == newRec.SingleMovieId) || !db.Users.Any(u => u.Id == newRec.RecUserId) || !db.Movies.Any(m => m.Id == newRec.RecommendedMovieId))
+                if (!db.Movies.Any(m => m.Id == newRecDto.SingleMovieId) || !db.Users.Any(u => u.Id == newRecDto.RecUserId) || !db.Movies.Any(m => m.Id == newRecDto.RecommendedMovieId))
                 {
                     return Results.NotFound();
                 }
 
-                db.Recommendations.Add(newRec);
+                Recommendation newRecommendation = new()
+                {
+                    RecUserId = newRecDto.RecUserId,
+                    SingleMovieId = newRecDto.SingleMovieId,
+                    RecommendedMovieId = newRecDto.RecommendedMovieId
+                };
+
+                db.Recommendations.Add(newRecommendation);
                 db.SaveChanges();
-                return Results.Created($"/recommendations/{newRec.Id}", newRec);
+                return Results.Created($"/recommendations/{newRecommendation.Id}", newRecommendation);
 
             });
 

--- a/Dto/RecommendationsDto.cs
+++ b/Dto/RecommendationsDto.cs
@@ -1,0 +1,14 @@
+﻿using MoviesBE.Models;
+using System.ComponentModel.DataAnnotations;
+
+namespace MoviesBE.Dto
+{
+    public class RecommendationsDto
+    {
+        public int RecUserId { get; set; }
+
+        public int SingleMovieId { get; set; }
+
+        public int RecommendedMovieId { get; set; }
+    }
+}

--- a/Migrations/20240501213431_shariCreate.Designer.cs
+++ b/Migrations/20240501213431_shariCreate.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MoviesBE.Migrations
 {
     [DbContext(typeof(MoviesBEDbContext))]
-    partial class MoviesBEDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240501213431_shariCreate")]
+    partial class shariCreate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20240501213431_shariCreate.cs
+++ b/Migrations/20240501213431_shariCreate.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MoviesBE.Migrations
+{
+    public partial class shariCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(8942));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(8995));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(8998));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9000));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9002));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9005));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9007));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9009));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9011));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9014));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "DateCreated",
+                value: new DateTime(2024, 4, 29, 19, 36, 14, 536, DateTimeKind.Local).AddTicks(9644));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "DateCreated",
+                value: new DateTime(2024, 4, 29, 19, 36, 14, 536, DateTimeKind.Local).AddTicks(9717));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "DateCreated",
+                value: new DateTime(2024, 4, 29, 19, 36, 14, 536, DateTimeKind.Local).AddTicks(9721));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "DateCreated",
+                value: new DateTime(2024, 4, 29, 19, 36, 14, 536, DateTimeKind.Local).AddTicks(9725));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "DateCreated",
+                value: new DateTime(2024, 4, 29, 19, 36, 14, 536, DateTimeKind.Local).AddTicks(9728));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "DateCreated",
+                value: new DateTime(2024, 4, 29, 19, 36, 14, 536, DateTimeKind.Local).AddTicks(9733));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "DateCreated",
+                value: new DateTime(2024, 4, 29, 19, 36, 14, 536, DateTimeKind.Local).AddTicks(9736));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "DateCreated",
+                value: new DateTime(2024, 4, 29, 19, 36, 14, 536, DateTimeKind.Local).AddTicks(9740));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "DateCreated",
+                value: new DateTime(2024, 4, 29, 19, 36, 14, 536, DateTimeKind.Local).AddTicks(9744));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "DateCreated",
+                value: new DateTime(2024, 4, 29, 19, 36, 14, 536, DateTimeKind.Local).AddTicks(9748));
+        }
+    }
+}

--- a/Migrations/20240501214143_recommendations.Designer.cs
+++ b/Migrations/20240501214143_recommendations.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -10,9 +11,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MoviesBE.Migrations
 {
     [DbContext(typeof(MoviesBEDbContext))]
-    partial class MoviesBEDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240501214143_recommendations")]
+    partial class recommendations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20240501214143_recommendations.cs
+++ b/Migrations/20240501214143_recommendations.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace MoviesBE.Migrations
+{
+    public partial class recommendations : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MovieUser");
+
+            migrationBuilder.CreateTable(
+                name: "Recommendations",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    RecUserId = table.Column<int>(type: "integer", nullable: false),
+                    SingleMovieId = table.Column<int>(type: "integer", nullable: false),
+                    RecommendedMovieId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Recommendations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Recommendations_Movies_RecommendedMovieId",
+                        column: x => x.RecommendedMovieId,
+                        principalTable: "Movies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Recommendations_Movies_SingleMovieId",
+                        column: x => x.SingleMovieId,
+                        principalTable: "Movies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Recommendations_Users_RecUserId",
+                        column: x => x.RecUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserMovie",
+                columns: table => new
+                {
+                    MovieId = table.Column<int>(type: "integer", nullable: false),
+                    UserId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserMovie", x => new { x.MovieId, x.UserId });
+                    table.ForeignKey(
+                        name: "FK_UserMovie_Movies_MovieId",
+                        column: x => x.MovieId,
+                        principalTable: "Movies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserMovie_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 41, 43, 169, DateTimeKind.Local).AddTicks(8621));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 41, 43, 169, DateTimeKind.Local).AddTicks(8678));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 41, 43, 169, DateTimeKind.Local).AddTicks(8681));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 41, 43, 169, DateTimeKind.Local).AddTicks(8683));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 41, 43, 169, DateTimeKind.Local).AddTicks(8686));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 41, 43, 169, DateTimeKind.Local).AddTicks(8688));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 41, 43, 169, DateTimeKind.Local).AddTicks(8719));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 41, 43, 169, DateTimeKind.Local).AddTicks(8722));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 41, 43, 169, DateTimeKind.Local).AddTicks(8725));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 41, 43, 169, DateTimeKind.Local).AddTicks(8727));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Recommendations_RecUserId",
+                table: "Recommendations",
+                column: "RecUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Recommendations_RecommendedMovieId",
+                table: "Recommendations",
+                column: "RecommendedMovieId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Recommendations_SingleMovieId",
+                table: "Recommendations",
+                column: "SingleMovieId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserMovie_UserId",
+                table: "UserMovie",
+                column: "UserId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Recommendations");
+
+            migrationBuilder.DropTable(
+                name: "UserMovie");
+
+            migrationBuilder.CreateTable(
+                name: "MovieUser",
+                columns: table => new
+                {
+                    MoviesId = table.Column<int>(type: "integer", nullable: false),
+                    UsersId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MovieUser", x => new { x.MoviesId, x.UsersId });
+                    table.ForeignKey(
+                        name: "FK_MovieUser_Movies_MoviesId",
+                        column: x => x.MoviesId,
+                        principalTable: "Movies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_MovieUser_Users_UsersId",
+                        column: x => x.UsersId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(8942));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(8995));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(8998));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9000));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9002));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9005));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9007));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9009));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9011));
+
+            migrationBuilder.UpdateData(
+                table: "Reviews",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "DateCreated",
+                value: new DateTime(2024, 5, 1, 16, 34, 31, 397, DateTimeKind.Local).AddTicks(9014));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MovieUser_UsersId",
+                table: "MovieUser",
+                column: "UsersId");
+        }
+    }
+}

--- a/Models/Movie.cs
+++ b/Models/Movie.cs
@@ -1,26 +1,28 @@
 ﻿using System.ComponentModel.DataAnnotations;
-namespace MoviesBE.Models;
-
-public class Movie
+namespace MoviesBE.Models
 {
-    public int Id { get; set; }
-    public string Title { get; set; }
-    public string Image { get; set; }
-    public string Description { get; set; }
-    public DateTime DateReleased { get; set; }
-    public ICollection<Genre> Genres { get; set; }
-    public ICollection<User> Users { get; set; }
-    public List<Review> Reviews { get; set; }
-    public decimal MovieRating
+    public class Movie
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Image { get; set; }
+        public string Description { get; set; }
+        public DateTime DateReleased { get; set; }
+        public ICollection<Genre> Genres { get; set; }
+        public ICollection<User> Users { get; set; }
+        public List<Recommendation> Recommendations { get; set; }
+        public List<Review> Reviews { get; set; }
+        public decimal MovieRating
         {
             get
             {
                 if (Reviews != null && Reviews.Any())
                 {
-                decimal value = (Reviews.Sum(r => r.Rating) / Reviews.Count());
-                return Math.Round(value, 2);
+                    decimal value = (Reviews.Sum(r => r.Rating) / Reviews.Count());
+                    return Math.Round(value, 2);
                 }
                 return 0;
             }
         }
+    }
 }

--- a/Models/Recommendation.cs
+++ b/Models/Recommendation.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MoviesBE.Models
+{
+    public class Recommendation
+    {
+        public int Id { get; set; }
+        public int RecUserId { get; set; }
+        public User RecUser { get; set; }
+
+        public int SingleMovieId { get; set; }
+        public Movie SingleMovie { get; set; }
+
+        public int RecommendedMovieId { get; set; }
+        public Movie RecommendedMovie { get; set; }
+
+    }
+}

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -1,13 +1,14 @@
 ﻿using System.ComponentModel.DataAnnotations;
 namespace MoviesBE.Models;
-    public class User
-    {
+public class User
+{
     public int Id { get; set; }
     public string Name { get; set; }
     public string? Image { get; set; }
     public string Email { get; set; }
     public bool IsAdmin { get; set; }
+    public List<Recommendation> Recommendations { get; set; }
     public ICollection<Movie> Movies { get; set; }
+
     public string Uid { get; set; }
 }
-

--- a/MoviesBEDbContext.cs
+++ b/MoviesBEDbContext.cs
@@ -7,10 +7,42 @@ public class MoviesBEDbContext : DbContext
     public DbSet<Genre> Genres { get; set; }
     public DbSet<Review> Reviews { get; set; }
     public DbSet<User> Users { get; set; }
-  
+    public DbSet<Recommendation> Recommendations { get; set; }
+
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        // Configure many-to-many relationship between User and Movie for general movie recommendations (not user-specific)
+        modelBuilder.Entity<User>()
+            .HasMany(u => u.Movies)
+            .WithMany(m => m.Users)
+            .UsingEntity<Dictionary<string, object>>(
+                "UserMovie",
+                j => j
+                    .HasOne<Movie>()
+                    .WithMany()
+                    .HasForeignKey("MovieId"),
+                j => j
+                    .HasOne<User>()
+                    .WithMany()
+                    .HasForeignKey("UserId")
+            );
+
+        modelBuilder.Entity<Movie>()
+               .HasMany(m => m.Recommendations) // Movie has many Recommendations
+               .WithOne(r => r.SingleMovie) // Recommendation has one SingleMovie
+               .HasForeignKey(r => r.SingleMovieId); // Foreign key in Recommendation pointing to Movie
+
+        modelBuilder.Entity<Recommendation>()
+            .HasOne(r => r.RecommendedMovie) // Recommendation has one RecommendedMovie
+            .WithMany() // RecommendedMovie can have many Recommendations
+            .HasForeignKey(r => r.RecommendedMovieId); // Foreign key in Recommendation pointing to Movie
+
+        modelBuilder.Entity<Movie>()
+               .HasMany(m => m.Genres)
+               .WithMany(g => g.Movies)
+               .UsingEntity(j => j.ToTable("GenreMovie"));
+
 
         modelBuilder.Entity<User>().HasData(new User[]
 {


### PR DESCRIPTION
Api calls added:

- add movie recommendatin
- delete movie recommendation
- view user's recommendations
- view single movie's recommendations
- Api Fluency was added for all models to show their relationship (See screenshot below)

## Description
We have a many-to-many relationship between Users being able to add a movie recommendation to a movie. Many Users can recommend. Many movies can receive recommendations.

## Related Issue
Relates to viewing movies and users detail page

## Motivation and Context
On the single movie page, we wanted the users to be able to add movie recommendation for each movie.

## How Can This Be Tested?
In Swagger: Delete should return as success. Add should show: RecUserId, SingleMovieId, RecommendedMovieId. View should show the user object with the rec movie objects.

## Screenshots (if appropriate):
![image](https://github.com/GitEbachS/MoviesBE/assets/119310701/f5887b24-10ad-4af8-8f1c-cc6fb64b7af7)

![Screenshot 2024-05-01 165835](https://github.com/GitEbachS/MoviesBE/assets/119310701/accb5b87-9e76-4325-abae-ef8b5fbd6533)
![Screenshot 2024-05-01 164527](https://github.com/GitEbachS/MoviesBE/assets/119310701/0930c6d3-744a-42f1-b042-36e1c35d97da)

![Screenshot 2024-05-01 164537](https://github.com/GitEbachS/MoviesBE/assets/119310701/be271183-8ae7-4cf1-bb79-4b3ff16659e1)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)